### PR TITLE
Bgc/improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkitTolerances"
 uuid = "cca81fe9-e5fd-44f6-ad29-5b4f39e14206"
 authors = ["Brad Carman <bradleygcarman@gmail.com>"]
-version = "0.4.0"
+version = "0.5.0"
 
 [deps]
 FilterHelpers = "d8f44d74-4a63-4059-add9-16c5740a0809"
@@ -10,6 +10,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [weakdeps]
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
@@ -21,9 +22,10 @@ PlotsExt = "Plots"
 FilterHelpers = "0.2.0"
 ForwardDiff = "0.10.38"
 LinearAlgebra = "1.9.0"
-ModelingToolkit = "9"
+ModelingToolkit = "10"
 PrettyTables = "2.4.0"
 SciMLBase = "2.107.0"
+Symbolics = "6.51.0"
 julia = "1.9"
 
 [extras]

--- a/src/ModelingToolkitTolerances.jl
+++ b/src/ModelingToolkitTolerances.jl
@@ -49,29 +49,33 @@ Keyword Arguments (used by `analysis() function`):
 """
 function residual(sol::ODESolution, tms = default_range(sol); abstol=0.0, reltol=0.0, timing=0.0)
     #NOTE: we re-create the ODEProblem so we have the full f function (this seems to be dropped from the ODESolution)
-    prob = ODEProblem(sol.prob.f.sys, sol(0.0), (tms[1], tms[end]); build_initializeprob=false)
-    f = prob.f
+    # prob = ODEProblem(sol.prob.f.sys, sol(0.0), (tms[1], tms[end]); build_initializeprob=false)
+    # f = prob.f
     #f_oop = f.f_oop
 
-    function f_oop(u, p, t) 
-        du = similar(u)
-        f(du, u, p, t)
-        return du
-    end
+    # function f_oop(u, p, t) 
+    #     du = similar(u)
+    #     f(du, u, p, t)
+    #     return du
+    # end
 
+    prob = sol.prob
+    f = prob.f
     p = prob.p
     sys = f.sys
     eqs = full_equations(sys)
     ps = parameters(sys)
     sts = unknowns(sys)
-    st_vals = [st => sol(tms; idxs=st).u for st in sts]
-    p_vals = [p => sol(0.0; idxs=p) for p in ps]
+    # st_vals = [st => sol(tms; idxs=st).u for st in sts]
+    # p_vals = [p => sol(0.0; idxs=p) for p in ps]
     n = length(tms)
 
     differential_vars = Int[]
     algebraic_vars = Int[]
     residuals = Vector{Float64}[]
-    rhs_data = hcat([f_oop(sol(tm), p, tm) for tm in tms]...)
+    # rhs_data = hcat([f_oop(sol(tm), p, tm) for tm in tms]...)
+
+
     for (i,eq) in enumerate(eqs)
 
         lhs = eq.lhs
@@ -85,8 +89,10 @@ function residual(sol::ODESolution, tms = default_range(sol); abstol=0.0, reltol
             push!(algebraic_vars, i)
             zero.(tms)
         end
+        
+        rhs_data = sol(tms; idxs=rhs)
 
-        residual = rhs_data[i,:] .- lhs_data
+        residual = rhs_data .- lhs_data
 
         push!(residuals, residual)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ end
 eqs = [
     D(T) ~ (h * A) / (m * c_p) * (T_inf - T)
 ]
-@mtkbuild sys = ODESystem(eqs, t, vars, [])
+@mtkcompile sys = System(eqs, t, vars, [])
 prob = ODEProblem(sys, [], (0, 10))
 sol = solve(prob, Tsit5())
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,3 +41,18 @@ p = plot(res)
 @test p isa Plots.Plot
 p = plot(resids)
 @test p isa Plots.Plot
+
+
+# Check equation manipulation
+@variables x(t)
+eq = D(x) ~ x
+new_eq = ModelingToolkitTolerances.move_differentials_to_lhs(eq)
+@test isequal(new_eq.rhs, x)
+
+eq = 0 ~ D(x) + x
+new_eq = ModelingToolkitTolerances.move_differentials_to_lhs(eq)
+@test isequal(new_eq.rhs, -x)
+
+eq = 0 ~ 2D(x) + x
+new_eq = ModelingToolkitTolerances.move_differentials_to_lhs(eq)
+@test isequal(new_eq.rhs, -x/2)


### PR DESCRIPTION
- fixed the analysis tms default
- fixed the `no_simplify` function to move derivatives to the lhs
- improved the residual function to correctly calculate the rhs when there are discrete variables in the system